### PR TITLE
Move busboy to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,13 +16,15 @@
     "prepublish": "standard"
   },
   "dependencies": {
-    "busboy": "0.2.13",
     "debug": "2.2.0",
     "once": "1.3.3",
     "uuid": "2.0.1"
   },
   "devDependencies": {
     "standard": "6.0.8"
+  },
+  "peerDependencies": {
+    "busboy": "^0.2.13"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
So that busboy-wrapper would use the busboy installed by the parent package, instead of installing its own copy of it.

See https://nodejs.org/en/blog/npm/peer-dependencies/
